### PR TITLE
Add offline packaging to deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,20 @@ jobs:
             pm2 restart kqp-control-fe
           "
 
+      - name: Package offline bundle
+        run: |
+          chmod +x scripts/package-offline.sh
+          scripts/package-offline.sh
+
+      - name: Upload offline package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: kqp-control-fe-offline-${{ github.run_id }}
+          path: |
+            artifacts/kqp-control-fe-offline-*.tar.gz
+            artifacts/kqp-control-fe-offline-*.tar.gz.sha256
+          if-no-files-found: error
+
       - name: Cleanup
         if: always()
         run: rm -f deploy_key

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ _static
 out
 dist
 build
+artifacts
 
 # environment variables
 .env

--- a/scripts/package-offline.sh
+++ b/scripts/package-offline.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_DIR="${ROOT_DIR}/artifacts"
+TIMESTAMP="$(date -u +"%Y%m%dT%H%M%SZ")"
+PACKAGE_NAME="kqp-control-fe-offline-${TIMESTAMP}.tar.gz"
+STAGING_DIR="${OUTPUT_DIR}/staging"
+
+mkdir -p "${OUTPUT_DIR}"
+rm -rf "${STAGING_DIR}"
+mkdir -p "${STAGING_DIR}"
+
+echo "Preparing offline package workspace at ${STAGING_DIR}" >&2
+
+rsync -a \
+  --exclude ".git" \
+  --exclude ".github" \
+  --exclude "artifacts" \
+  --exclude "deploy_key" \
+  --exclude "*.log" \
+  --exclude "node_modules/.cache" \
+  --exclude "tmp" \
+  "${ROOT_DIR}/" "${STAGING_DIR}/"
+
+tar -czf "${OUTPUT_DIR}/${PACKAGE_NAME}" -C "${STAGING_DIR}" .
+sha256sum "${OUTPUT_DIR}/${PACKAGE_NAME}" > "${OUTPUT_DIR}/${PACKAGE_NAME}.sha256"
+
+echo "Offline package created: ${OUTPUT_DIR}/${PACKAGE_NAME}" >&2
+echo "Checksum written to: ${OUTPUT_DIR}/${PACKAGE_NAME}.sha256" >&2


### PR DESCRIPTION
## Summary
- add a packaging script that tars the repository and dependency tree for offline use and generates a checksum
- run the packaging script from the deployment workflow after the deploy step and upload the tarball as an artifact
- ignore the generated artifacts directory in git

## Testing
- ./scripts/package-offline.sh

------
https://chatgpt.com/codex/tasks/task_e_68f016b1bd308330a536e228c944a950