### PR TITLE
feat: deploy-pack.sh 분할 크기 인자 지정 지원

### DIFF
--- a/scripts/deploy-pack.sh
+++ b/scripts/deploy-pack.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 # 배포용 분할 압축 스크립트
-# 프로젝트 디렉터리를 99MB 이하로 분할 압축합니다.
+# 프로젝트 디렉터리를 지정 크기 이하로 분할 압축합니다.
+# 사용법: deploy-pack.sh [출력경로] [분할크기(MB)]
 # 제외 대상: CLAUDE.md, .git/, .github/, .gitignore, scripts/, .env.local, .claude/
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -10,7 +11,8 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 PROJECT_NAME="$(basename "$PROJECT_DIR")"
 
 OUTPUT_DIR="${1:-$(dirname "$PROJECT_DIR")/deploy-output}"
-SPLIT_SIZE="99m"
+SPLIT_MB="${2:-99}"
+SPLIT_SIZE="${SPLIT_MB}m"
 TODAY="$(date +%d%m%y)"
 FILE_PREFIX="${PROJECT_NAME}_${TODAY}.tar.gz.part_"
 
@@ -22,7 +24,7 @@ rm -f "$OUTPUT_DIR/${PROJECT_NAME}_"*.tar.gz.part_*
 echo "=== 배포용 분할 압축 시작 ==="
 echo "프로젝트: $PROJECT_DIR"
 echo "출력 경로: $OUTPUT_DIR"
-echo "분할 크기: ${SPLIT_SIZE}B 이하"
+echo "분할 크기: ${SPLIT_MB}MB 이하"
 echo ""
 
 # tar 압축 + split 분할


### PR DESCRIPTION
## Summary
- `deploy-pack.sh`의 분할 압축 크기를 두 번째 인자로 지정 가능하도록 개선
- 기본값은 기존과 동일하게 99MB 유지
- 예: `./scripts/deploy-pack.sh /path/to/output 19` → 19MB 단위로 분할

## Test plan
- [x] 19MB 인자 전달 시 19MB 단위로 분할되는 것 확인 (34개 파일 생성)
- [x] 인자 없이 실행 시 기존 기본값(99MB) 유지 확인

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)