### PR TITLE
Responsive layout: compact sidebar, continuous zoom, hover scrollbars, Data Flow

### DIFF
--- a/src/components/data-flow/DataFlowCanvas.tsx
+++ b/src/components/data-flow/DataFlowCanvas.tsx
@@ -23,6 +23,8 @@ import Typography from '@mui/material/Typography';
 import { T } from 'src/theme/tokens';
 import { useTranslate } from 'src/locales';
 
+import { getViewportScale } from 'src/components/viewport-zoom';
+
 import { DataFlowToolbar } from './DataFlowToolbar';
 import { DataFlowNode } from './nodes/DataFlowNode';
 import { buildDataFlowGraph } from './graph-builder';
@@ -46,6 +48,19 @@ function DataFlowCanvasInner({ definition, fileName }: DataFlowCanvasProps) {
   const { fitView, zoomTo, getZoom } = useReactFlow();
   const nodesInitialized = useNodesInitialized();
   const [zoom, setZoom] = useState(95);
+
+  // The app applies a root CSS `zoom` (<html>) to fit smaller viewports. React
+  // Flow can't see that zoom, so it mis-measures handle/edge geometry and the
+  // edges drift off the connection dots — worse the smaller the screen (zoom
+  // further from 1). We counteract it by applying the inverse `zoom` on the
+  // canvas pane so React Flow renders at an effective root zoom of 1.
+  const [docScale, setDocScale] = useState(1);
+  useEffect(() => {
+    const update = () => setDocScale(getViewportScale());
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, []);
 
   // Zoom % follows a clean 5-step sequence (…, 90, 95, 100, …), clamped to the
   // ReactFlow min/max zoom (0.1–2 ⇒ 10–200%).
@@ -73,11 +88,9 @@ function DataFlowCanvasInner({ definition, fileName }: DataFlowCanvasProps) {
     return { nodes: laidOut, edges };
   }, [definition]);
 
-  const [nodes, setNodes, onNodesChange] =
-    useNodesState<DataFlowNodeInstance>(initialGraph.nodes);
+  const [nodes, setNodes, onNodesChange] = useNodesState<DataFlowNodeInstance>(initialGraph.nodes);
 
-  const [edges, setEdges, onEdgesChange] =
-    useEdgesState<Edge>(initialGraph.edges);
+  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>(initialGraph.edges);
 
   // Sync nodes/edges when definition changes
   useEffect(() => {
@@ -96,12 +109,10 @@ function DataFlowCanvasInner({ definition, fileName }: DataFlowCanvasProps) {
   }, [nodesInitialized, fitView]);
 
   useEffect(() => {
-    const handleChange = () =>
-      setIsFullscreen(!!document.fullscreenElement);
+    const handleChange = () => setIsFullscreen(!!document.fullscreenElement);
 
     document.addEventListener('fullscreenchange', handleChange);
-    return () =>
-      document.removeEventListener('fullscreenchange', handleChange);
+    return () => document.removeEventListener('fullscreenchange', handleChange);
   }, []);
 
   // Track zoom % (snapped to the nearest 5-step)
@@ -112,8 +123,12 @@ function DataFlowCanvasInner({ definition, fileName }: DataFlowCanvasProps) {
   // Track hover so keyboard shortcuts only fire over the canvas
   useEffect(() => {
     const el = containerRef.current;
-    const onEnter = () => { isHoveredRef.current = true; };
-    const onLeave = () => { isHoveredRef.current = false; };
+    const onEnter = () => {
+      isHoveredRef.current = true;
+    };
+    const onLeave = () => {
+      isHoveredRef.current = false;
+    };
     if (el) {
       el.addEventListener('mouseenter', onEnter);
       el.addEventListener('mouseleave', onLeave);
@@ -167,118 +182,149 @@ function DataFlowCanvasInner({ definition, fileName }: DataFlowCanvasProps) {
       <DataFlowToolbar fileName={fileName} />
 
       <Box sx={{ flex: 1, position: 'relative' }}>
-        <ReactFlow
-          nodes={nodes}
-          edges={edges}
-          onNodesChange={onNodesChange}
-          onEdgesChange={onEdgesChange}
-          nodeTypes={nodeTypes}
-          fitView
-          minZoom={0.1}
-          maxZoom={2}
-          fitViewOptions={{ padding: 0.08, maxZoom: 0.7 }}
-          proOptions={{ hideAttribution: true }}
-          nodesDraggable
-          nodesConnectable={false}
-          elementsSelectable={false}
-          onInit={handleViewportChange}
-          onMoveEnd={handleViewportChange}
-          defaultEdgeOptions={{ type: 'smoothstep' }}
-
-          zoomOnScroll={false}
-          panOnScroll
-          preventScrolling
-          zoomOnPinch
-          panOnDrag
+        <Box
+          // `zoom` (React inline style, unitless) — inverse of the root zoom so
+          // React Flow sees an effective root zoom of 1. Width/height are scaled
+          // by docScale so this layer still fills the pane on screen.
+          style={{ zoom: 1 / docScale }}
+          sx={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: `${docScale * 100}%`,
+            height: `${docScale * 100}%`,
+          }}
         >
-          <Background
-            variant={BackgroundVariant.Lines}
-            gap={50}
-            lineWidth={1}
-            color={GRID_LINE_COLOR}
-          />
+          <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            onNodesChange={onNodesChange}
+            onEdgesChange={onEdgesChange}
+            nodeTypes={nodeTypes}
+            fitView
+            minZoom={0.1}
+            maxZoom={2}
+            fitViewOptions={{ padding: 0.08, maxZoom: 0.7 }}
+            proOptions={{ hideAttribution: true }}
+            nodesDraggable
+            nodesConnectable={false}
+            elementsSelectable={false}
+            onInit={handleViewportChange}
+            onMoveEnd={handleViewportChange}
+            defaultEdgeOptions={{ type: 'smoothstep' }}
+            zoomOnScroll={false}
+            panOnScroll
+            preventScrolling
+            zoomOnPinch
+            panOnDrag
+          >
+            <Background
+              variant={BackgroundVariant.Lines}
+              gap={50}
+              lineWidth={1}
+              color={GRID_LINE_COLOR}
+            />
 
-          {/* Help text */}
-          <Panel position="top-left">
-            <Typography
-              sx={{
-                color: HELP_TEXT_COLOR,
-                fontSize: 17,
-                fontFamily: "'Spoqa Han Sans Neo'",
-                fontWeight: 400,
-              }}
-            >
-              {t('canvas.zoom_help')}
-            </Typography>
-          </Panel>
-
-          {/* Zoom Controls */}
-          <Panel position="top-right">
-            <Box
-              sx={{
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'center',
-                backgroundColor: T.bgCard,
-                border: `1px solid ${T.border}`,
-                borderRadius: '8px',
-                overflow: 'hidden',
-                userSelect: 'none',
-              }}
-            >
-              <Box
-                onClick={() => stepZoom(1)}
-                sx={{
-                  width: 30,
-                  height: 28,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  color: T.textSec,
-                  cursor: 'pointer',
-                  '&:hover': { backgroundColor: T.bgHover, color: T.textPrim },
-                }}
-              >
-                <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M7.99902 2C8.29353 2 8.53313 2.23871 8.5332 2.5332V7.4668H13.4668C13.7612 7.46687 13.9999 7.70555 14 8C14 8.29451 13.7613 8.53313 13.4668 8.5332H8.5332V13.4668C8.5332 13.7613 8.29358 14 7.99902 14C7.70468 13.9998 7.46582 13.7612 7.46582 13.4668V8.5332H2.5332C2.23871 8.53313 2 8.29451 2 8C2.00007 7.70555 2.23875 7.46687 2.5332 7.4668H7.46582V2.5332C7.46589 2.23886 7.70472 2.00025 7.99902 2Z" fill="currentColor" />
-                </svg>
-              </Box>
-
+            {/* Help text */}
+            <Panel position="top-left">
               <Typography
                 sx={{
-                  fontSize: 13,
-                  color: T.textSec,
+                  color: HELP_TEXT_COLOR,
+                  fontSize: 17,
                   fontFamily: "'Spoqa Han Sans Neo'",
-                  py: '3px',
-                  width: '100%',
-                  textAlign: 'center',
-                  borderTop: `1px solid ${T.border}`,
-                  borderBottom: `1px solid ${T.border}`,
+                  fontWeight: 400,
                 }}
               >
-                {zoom}%
+                {t('canvas.zoom_help')}
               </Typography>
+            </Panel>
 
+            {/* Zoom Controls */}
+            <Panel position="top-right">
               <Box
-                onClick={() => stepZoom(-1)}
                 sx={{
-                  width: 30,
-                  height: 28,
                   display: 'flex',
+                  flexDirection: 'column',
                   alignItems: 'center',
-                  justifyContent: 'center',
-                  color: T.textSec,
-                  cursor: 'pointer',
-                  '&:hover': { backgroundColor: T.bgHover, color: T.textPrim },
+                  backgroundColor: T.bgCard,
+                  border: `1px solid ${T.border}`,
+                  borderRadius: '8px',
+                  overflow: 'hidden',
+                  userSelect: 'none',
                 }}
               >
-                <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M13.4668 7.4668C13.7612 7.46687 13.9999 7.70555 14 8C14 8.29451 13.7613 8.53313 13.4668 8.5332H2.5332C2.23871 8.53313 2 8.29451 2 8C2.00007 7.70555 2.23875 7.46687 2.5332 7.4668H13.4668Z" fill="currentColor" />
-                </svg>
+                <Box
+                  onClick={() => stepZoom(1)}
+                  sx={{
+                    width: 30,
+                    height: 28,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    color: T.textSec,
+                    cursor: 'pointer',
+                    '&:hover': { backgroundColor: T.bgHover, color: T.textPrim },
+                  }}
+                >
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M7.99902 2C8.29353 2 8.53313 2.23871 8.5332 2.5332V7.4668H13.4668C13.7612 7.46687 13.9999 7.70555 14 8C14 8.29451 13.7613 8.53313 13.4668 8.5332H8.5332V13.4668C8.5332 13.7613 8.29358 14 7.99902 14C7.70468 13.9998 7.46582 13.7612 7.46582 13.4668V8.5332H2.5332C2.23871 8.53313 2 8.29451 2 8C2.00007 7.70555 2.23875 7.46687 2.5332 7.4668H7.46582V2.5332C7.46589 2.23886 7.70472 2.00025 7.99902 2Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </Box>
+
+                <Typography
+                  sx={{
+                    fontSize: 13,
+                    color: T.textSec,
+                    fontFamily: "'Spoqa Han Sans Neo'",
+                    py: '3px',
+                    width: '100%',
+                    textAlign: 'center',
+                    borderTop: `1px solid ${T.border}`,
+                    borderBottom: `1px solid ${T.border}`,
+                  }}
+                >
+                  {zoom}%
+                </Typography>
+
+                <Box
+                  onClick={() => stepZoom(-1)}
+                  sx={{
+                    width: 30,
+                    height: 28,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    color: T.textSec,
+                    cursor: 'pointer',
+                    '&:hover': { backgroundColor: T.bgHover, color: T.textPrim },
+                  }}
+                >
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M13.4668 7.4668C13.7612 7.46687 13.9999 7.70555 14 8C14 8.29451 13.7613 8.53313 13.4668 8.5332H2.5332C2.23871 8.53313 2 8.29451 2 8C2.00007 7.70555 2.23875 7.46687 2.5332 7.4668H13.4668Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </Box>
               </Box>
-            </Box>
-          </Panel>
-        </ReactFlow>
+            </Panel>
+          </ReactFlow>
+        </Box>
       </Box>
     </Box>
   );

--- a/src/components/data-flow/DataFlowCanvas.tsx
+++ b/src/components/data-flow/DataFlowCanvas.tsx
@@ -102,11 +102,17 @@ function DataFlowCanvasInner({ definition, fileName }: DataFlowCanvasProps) {
   // prop runs before dynamic-height nodes are sized, so it mis-centers on load.
   // Force zoom to 95% (min=max) so we start centred on the graph's middle,
   // showing only part of it rather than the whole (which would shrink to ~25%).
+  //
+  // The counter-zoom decouples React Flow from the root zoom (so edges stay
+  // aligned), which also means the graph would NOT shrink with the responsive
+  // layout. Fold docScale into the graph's zoom so it scales down in step with
+  // the rest of the app (and re-fit when the viewport scale changes).
   useEffect(() => {
     if (!nodesInitialized) return;
-    fitView({ padding: 0.08, minZoom: 0.95, maxZoom: 0.95 });
-    setZoom(95);
-  }, [nodesInitialized, fitView]);
+    const z = 0.95 * docScale;
+    fitView({ padding: 0.08, minZoom: z, maxZoom: z });
+    setZoom(Math.round((z * 100) / 5) * 5);
+  }, [nodesInitialized, fitView, docScale]);
 
   useEffect(() => {
     const handleChange = () => setIsFullscreen(!!document.fullscreenElement);
@@ -191,8 +197,8 @@ function DataFlowCanvasInner({ definition, fileName }: DataFlowCanvasProps) {
             position: 'absolute',
             top: 0,
             left: 0,
-            width: `${docScale * 100}%`,
-            height: `${docScale * 100}%`,
+            width: '100%',
+            height: '100%',
           }}
         >
           <ReactFlow
@@ -201,10 +207,8 @@ function DataFlowCanvasInner({ definition, fileName }: DataFlowCanvasProps) {
             onNodesChange={onNodesChange}
             onEdgesChange={onEdgesChange}
             nodeTypes={nodeTypes}
-            fitView
             minZoom={0.1}
             maxZoom={2}
-            fitViewOptions={{ padding: 0.08, maxZoom: 0.7 }}
             proOptions={{ hideAttribution: true }}
             nodesDraggable
             nodesConnectable={false}
@@ -225,12 +229,14 @@ function DataFlowCanvasInner({ definition, fileName }: DataFlowCanvasProps) {
               color={GRID_LINE_COLOR}
             />
 
-            {/* Help text */}
+            {/* Help text — the counter-zoom decouples this panel from the root
+                zoom, so scale the font by docScale to keep it in step with the
+                responsive layout. */}
             <Panel position="top-left">
               <Typography
                 sx={{
                   color: HELP_TEXT_COLOR,
-                  fontSize: 17,
+                  fontSize: 17 * docScale,
                   fontFamily: "'Spoqa Han Sans Neo'",
                   fontWeight: 400,
                 }}

--- a/src/components/data-flow/TestEnvironmentModal.tsx
+++ b/src/components/data-flow/TestEnvironmentModal.tsx
@@ -374,6 +374,10 @@ export function TestEnvironmentModal({
     <Modal
       open={open}
       onClose={onClose}
+      // Opaque backdrop so the page behind the floating card is fully hidden
+      // (the default MUI backdrop is only 50% black, letting the previous
+      // screen show through the 20px inset around the card).
+      slotProps={{ backdrop: { sx: { backgroundColor: '#0B0A10' } } }}
     >
       <ReactFlowProvider>
         <ModalContent

--- a/src/components/data-flow/TestEnvironmentModal.tsx
+++ b/src/components/data-flow/TestEnvironmentModal.tsx
@@ -194,8 +194,8 @@ function ModalContent({
         display: 'flex',
         flexDirection: 'column',
         gap: 3,
-        scrollbarWidth: 'thin',
-        scrollbarColor: `${T.border} ${T.bg}`,
+        // Scrollbar styling deferred to the global hover-reveal rule (invisible
+        // at rest, shown when the modal body is hovered).
         pb: 6,
       }}
     >
@@ -221,7 +221,13 @@ function ModalContent({
           {/* Zoom label */}
           <Box sx={{ px: 1.5, py: 0.5, borderRadius: '4px' }}>
             <Typography
-              sx={{ fontSize: 14, fontWeight: 400, lineHeight: '16.8px', color: T.textDim, fontFamily: FONT_MONO }}
+              sx={{
+                fontSize: 14,
+                fontWeight: 400,
+                lineHeight: '16.8px',
+                color: T.textDim,
+                fontFamily: FONT_MONO,
+              }}
             >
               {zoom}%
             </Typography>
@@ -271,8 +277,19 @@ function ModalContent({
               '&:hover': { backgroundColor: T.bgHover },
             }}
           >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill={TEXT_TERTIARY} xmlns="http://www.w3.org/2000/svg">
-              <path fillRule="evenodd" clipRule="evenodd" d="M19.7344 8.40505C20.0628 8.7006 20.0894 9.20643 19.7939 9.53485L12.5947 17.5349C12.443 17.7034 12.2268 17.7997 12 17.7997C11.7732 17.7997 11.5571 17.7035 11.4054 17.5349L4.20537 9.53489C3.9098 9.20648 3.93643 8.70065 4.26484 8.40508C4.59324 8.10951 5.09908 8.13613 5.39464 8.46454L12 15.8038L18.6046 8.46457C18.9001 8.13615 19.4059 8.1095 19.7344 8.40505Z" fill={TEXT_TERTIARY} />
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill={TEXT_TERTIARY}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M19.7344 8.40505C20.0628 8.7006 20.0894 9.20643 19.7939 9.53485L12.5947 17.5349C12.443 17.7034 12.2268 17.7997 12 17.7997C11.7732 17.7997 11.5571 17.7035 11.4054 17.5349L4.20537 9.53489C3.9098 9.20648 3.93643 8.70065 4.26484 8.40508C4.59324 8.10951 5.09908 8.13613 5.39464 8.46454L12 15.8038L18.6046 8.46457C18.9001 8.13615 19.4059 8.1095 19.7344 8.40505Z"
+                fill={TEXT_TERTIARY}
+              />
             </svg>
           </Box>
 
@@ -292,8 +309,19 @@ function ModalContent({
               '&:hover': { backgroundColor: T.bgHover },
             }}
           >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill={TEXT_TERTIARY} xmlns="http://www.w3.org/2000/svg">
-              <path fillRule="evenodd" clipRule="evenodd" d="M18.6308 4.2347C18.9432 3.92248 19.4493 3.92236 19.7617 4.2347C20.074 4.54705 20.0739 5.05312 19.7617 5.36556L13.1288 11.9984L19.7656 18.6351C20.078 18.9475 20.078 19.4545 19.7656 19.7669C19.4532 20.0792 18.9471 20.0791 18.6347 19.7669L11.998 13.1292L5.36127 19.7669C5.04885 20.0791 4.54275 20.0792 4.23041 19.7669C3.91798 19.4545 3.918 18.9475 4.23041 18.6351L10.8662 11.9984L4.23431 5.36556C3.92209 5.05312 3.92196 4.54705 4.23431 4.2347C4.54667 3.92236 5.05275 3.92248 5.36517 4.2347L11.998 10.8675L18.6308 4.2347Z" fill={TEXT_TERTIARY} />
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill={TEXT_TERTIARY}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M18.6308 4.2347C18.9432 3.92248 19.4493 3.92236 19.7617 4.2347C20.074 4.54705 20.0739 5.05312 19.7617 5.36556L13.1288 11.9984L19.7656 18.6351C20.078 18.9475 20.078 19.4545 19.7656 19.7669C19.4532 20.0792 18.9471 20.0791 18.6347 19.7669L11.998 13.1292L5.36127 19.7669C5.04885 20.0791 4.54275 20.0792 4.23041 19.7669C3.91798 19.4545 3.918 18.9475 4.23041 18.6351L10.8662 11.9984L4.23431 5.36556C3.92209 5.05312 3.92196 4.54705 4.23431 4.2347C4.54667 3.92236 5.05275 3.92248 5.36517 4.2347L11.998 10.8675L18.6308 4.2347Z"
+                fill={TEXT_TERTIARY}
+              />
             </svg>
           </Box>
         </Stack>

--- a/src/components/v5/index.tsx
+++ b/src/components/v5/index.tsx
@@ -34,7 +34,14 @@ type PageShellProps = {
   children: ReactNode;
 };
 
-export function PageShell({ node, crumbs = [], title, actions, scroll = true, children }: PageShellProps) {
+export function PageShell({
+  node,
+  crumbs = [],
+  title,
+  actions,
+  scroll = true,
+  children,
+}: PageShellProps) {
   return (
     <Box
       sx={{
@@ -47,10 +54,23 @@ export function PageShell({ node, crumbs = [], title, actions, scroll = true, ch
       }}
     >
       {(node || crumbs.length > 0) && (
-        <Stack direction="row" alignItems="center" spacing={1} sx={{ px: 3, pt: 2.75, fontSize: 15, lineHeight: 1 }}>
+        <Stack
+          direction="row"
+          alignItems="center"
+          spacing={1}
+          sx={{ px: 3, pt: 2.75, fontSize: 15, lineHeight: 1 }}
+        >
           {node && (
             <>
-              <Box sx={{ width: 7, height: 7, borderRadius: '50%', bgcolor: T.on, boxShadow: `0 0 5px ${T.on}99` }} />
+              <Box
+                sx={{
+                  width: 7,
+                  height: 7,
+                  borderRadius: '50%',
+                  bgcolor: T.on,
+                  boxShadow: `0 0 5px ${T.on}99`,
+                }}
+              />
               <Typography sx={{ color: T.textPrim, fontSize: 15 }}>{node}</Typography>
             </>
           )}
@@ -75,8 +95,21 @@ export function PageShell({ node, crumbs = [], title, actions, scroll = true, ch
         </Stack>
       )}
 
-      <Stack direction="row" alignItems="flex-end" justifyContent="space-between" sx={{ px: 3, py: 2 }}>
-        <Typography sx={{ fontSize: 30, fontWeight: 500, letterSpacing: '-0.02em', lineHeight: 1, color: T.textPrim }}>
+      <Stack
+        direction="row"
+        alignItems="flex-end"
+        justifyContent="space-between"
+        sx={{ px: 3, py: 2 }}
+      >
+        <Typography
+          sx={{
+            fontSize: 30,
+            fontWeight: 500,
+            letterSpacing: '-0.02em',
+            lineHeight: 1,
+            color: T.textPrim,
+          }}
+        >
           {title}
         </Typography>
         {actions}
@@ -165,7 +198,20 @@ export function DataTable<R = any>({
         maxHeight,
       }}
     >
-      <Box component="table" sx={{ width: '100%', borderCollapse: 'collapse', fontSize: 16, lineHeight: 1.2 }}>
+      <Box
+        component="table"
+        sx={{
+          width: '100%',
+          // Don't let the table compress below its natural content width — the
+          // flexible (grow) column would otherwise be the only one to shrink and
+          // collapse. Instead the table keeps its column widths and the wrapper
+          // scrolls horizontally (scrollbar is hover-reveal, so it's unobtrusive).
+          minWidth: 'max-content',
+          borderCollapse: 'collapse',
+          fontSize: 16,
+          lineHeight: 1.2,
+        }}
+      >
         <Box component="thead">
           <Box component="tr">
             {columns.map((col) => (
@@ -200,7 +246,12 @@ export function DataTable<R = any>({
               <Box
                 component="td"
                 colSpan={columns.length}
-                sx={{ p: '28px 14px', textAlign: 'center', color: error ? T.off : T.textDim, fontSize: 15 }}
+                sx={{
+                  p: '28px 14px',
+                  textAlign: 'center',
+                  color: error ? T.off : T.textDim,
+                  fontSize: 15,
+                }}
               >
                 {placeholderText}
               </Box>
@@ -237,7 +288,8 @@ export function DataTable<R = any>({
                           maxWidth: col.grow ? 380 : undefined,
                           overflow: col.grow ? 'hidden' : undefined,
                           textOverflow: col.grow ? 'ellipsis' : undefined,
-                          boxShadow: selected && ci === 0 ? `inset 2px 0 0 0 ${T.primary}` : undefined,
+                          boxShadow:
+                            selected && ci === 0 ? `inset 2px 0 0 0 ${T.primary}` : undefined,
                         }}
                       >
                         {col.render ? col.render(row, ri) : (raw ?? '—')}
@@ -260,25 +312,105 @@ export function DataTable<R = any>({
 
 export function StatCard({ label, value }: { label: string; value: ReactNode }) {
   return (
-    <Box sx={{ flex: 1, bgcolor: T.bgCard, border: `1px solid ${T.border}`, borderRadius: '6px', p: '14px 18px', position: 'relative', overflow: 'hidden' }}>
-      <Typography sx={{ fontSize: 15, color: T.textSec, fontWeight: 500, textTransform: 'uppercase', letterSpacing: '0.06em', mb: 1.25 }}>
+    <Box
+      sx={{
+        flex: 1,
+        bgcolor: T.bgCard,
+        border: `1px solid ${T.border}`,
+        borderRadius: '6px',
+        p: '14px 18px',
+        position: 'relative',
+        overflow: 'hidden',
+      }}
+    >
+      <Typography
+        sx={{
+          fontSize: 15,
+          color: T.textSec,
+          fontWeight: 500,
+          textTransform: 'uppercase',
+          letterSpacing: '0.06em',
+          mb: 1.25,
+        }}
+      >
         {label}
       </Typography>
-      <Typography sx={{ fontSize: 34, fontWeight: 400, letterSpacing: '-0.03em', fontFamily: FONT_MONO, color: T.textPrim }}>
+      <Typography
+        sx={{
+          fontSize: 34,
+          fontWeight: 400,
+          letterSpacing: '-0.03em',
+          fontFamily: FONT_MONO,
+          color: T.textPrim,
+        }}
+      >
         {value}
       </Typography>
-      <Box sx={{ position: 'absolute', left: 0, right: 0, bottom: 0, height: 2, bgcolor: T.primary, opacity: 0.35 }} />
+      <Box
+        sx={{
+          position: 'absolute',
+          left: 0,
+          right: 0,
+          bottom: 0,
+          height: 2,
+          bgcolor: T.primary,
+          opacity: 0.35,
+        }}
+      />
     </Box>
   );
 }
 
 export function SummaryCard({ label, value }: { label: string; value: ReactNode }) {
   return (
-    <Box sx={{ flex: 1, bgcolor: T.bgCard, border: `1px solid ${T.border}`, borderRadius: '6px', p: '14px 16px', position: 'relative', overflow: 'hidden' }}>
-      <Typography sx={{ fontSize: 15, color: ACCENT2, fontWeight: 500, letterSpacing: '0.05em', mb: 1.5 }}>{label}</Typography>
-      <Typography sx={{ fontSize: 46, fontWeight: 400, letterSpacing: '-0.03em', color: T.textPrim, lineHeight: 1 }}>{value}</Typography>
-      <Box sx={{ position: 'absolute', left: 0, right: 0, bottom: 0, height: 40, background: `linear-gradient(to top, ${ACCENT2}22, transparent)` }} />
-      <Box sx={{ position: 'absolute', left: 0, right: 0, bottom: 0, height: 2, bgcolor: ACCENT2, opacity: 0.4 }} />
+    <Box
+      sx={{
+        flex: 1,
+        bgcolor: T.bgCard,
+        border: `1px solid ${T.border}`,
+        borderRadius: '6px',
+        p: '14px 16px',
+        position: 'relative',
+        overflow: 'hidden',
+      }}
+    >
+      <Typography
+        sx={{ fontSize: 15, color: ACCENT2, fontWeight: 500, letterSpacing: '0.05em', mb: 1.5 }}
+      >
+        {label}
+      </Typography>
+      <Typography
+        sx={{
+          fontSize: 46,
+          fontWeight: 400,
+          letterSpacing: '-0.03em',
+          color: T.textPrim,
+          lineHeight: 1,
+        }}
+      >
+        {value}
+      </Typography>
+      <Box
+        sx={{
+          position: 'absolute',
+          left: 0,
+          right: 0,
+          bottom: 0,
+          height: 40,
+          background: `linear-gradient(to top, ${ACCENT2}22, transparent)`,
+        }}
+      />
+      <Box
+        sx={{
+          position: 'absolute',
+          left: 0,
+          right: 0,
+          bottom: 0,
+          height: 2,
+          bgcolor: ACCENT2,
+          opacity: 0.4,
+        }}
+      />
     </Box>
   );
 }
@@ -287,10 +419,38 @@ export function SummaryCard({ label, value }: { label: string; value: ReactNode 
 // StatusBadge
 // ----------------------------------------------------------------------
 
-export function StatusBadge({ on, labelOn = 'active', labelOff = 'inactive', color, fontSize = 14, fontWeight = 300 }: { on: boolean; labelOn?: string; labelOff?: string; color?: string; fontSize?: number; fontWeight?: number }) {
+export function StatusBadge({
+  on,
+  labelOn = 'active',
+  labelOff = 'inactive',
+  color,
+  fontSize = 14,
+  fontWeight = 300,
+}: {
+  on: boolean;
+  labelOn?: string;
+  labelOff?: string;
+  color?: string;
+  fontSize?: number;
+  fontWeight?: number;
+}) {
   const c = color || (on ? T.on : T.off);
   return (
-    <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.625, fontSize, fontWeight, px: 1, py: '2px', borderRadius: '3px', letterSpacing: '0.03em', color: c }}>
+    <Box
+      component="span"
+      sx={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 0.625,
+        fontSize,
+        fontWeight,
+        px: 1,
+        py: '2px',
+        borderRadius: '3px',
+        letterSpacing: '0.03em',
+        color: c,
+      }}
+    >
       <Box sx={{ width: 5, height: 5, borderRadius: '50%', bgcolor: 'currentColor' }} />
       {on ? labelOn : labelOff}
     </Box>
@@ -328,9 +488,29 @@ const btnBase = {
   transition: 'background .12s, color .12s',
 } as const;
 
-export function BtnPrimary({ children, icon, onClick, disabled, type = 'button', weight }: BtnPrimaryProps) {
+export function BtnPrimary({
+  children,
+  icon,
+  onClick,
+  disabled,
+  type = 'button',
+  weight,
+}: BtnPrimaryProps) {
   return (
-    <Box component="button" type={type} onClick={onClick} disabled={disabled} sx={{ ...btnBase, ...(weight != null && { fontWeight: weight }), bgcolor: T.primary, color: '#fff', '&:hover': { bgcolor: T.primaryHov }, '&:disabled': { bgcolor: '#373F4E', color: '#667085', cursor: 'default' } }}>
+    <Box
+      component="button"
+      type={type}
+      onClick={onClick}
+      disabled={disabled}
+      sx={{
+        ...btnBase,
+        ...(weight != null && { fontWeight: weight }),
+        bgcolor: T.primary,
+        color: '#fff',
+        '&:hover': { bgcolor: T.primaryHov },
+        '&:disabled': { bgcolor: '#373F4E', color: '#667085', cursor: 'default' },
+      }}
+    >
       {icon && <Iconify icon={icon} width={15} />}
       {children}
     </Box>
@@ -339,7 +519,20 @@ export function BtnPrimary({ children, icon, onClick, disabled, type = 'button',
 
 export function BtnGhost({ children, icon, onClick, disabled, type = 'button' }: BtnProps) {
   return (
-    <Box component="button" type={type} onClick={onClick} disabled={disabled} sx={{ ...btnBase, bgcolor: T.bgCard, border: `1px solid ${T.border}`, color: T.textSec, '&:hover': { bgcolor: T.bgHover, color: T.textPrim }, '&:disabled': { bgcolor: '#373F4E', color: '#667085', cursor: 'default' } }}>
+    <Box
+      component="button"
+      type={type}
+      onClick={onClick}
+      disabled={disabled}
+      sx={{
+        ...btnBase,
+        bgcolor: T.bgCard,
+        border: `1px solid ${T.border}`,
+        color: T.textSec,
+        '&:hover': { bgcolor: T.bgHover, color: T.textPrim },
+        '&:disabled': { bgcolor: '#373F4E', color: '#667085', cursor: 'default' },
+      }}
+    >
       {icon && <Iconify icon={icon} width={15} />}
       {children}
     </Box>
@@ -348,7 +541,20 @@ export function BtnGhost({ children, icon, onClick, disabled, type = 'button' }:
 
 export function BtnDanger({ children, icon, onClick, disabled, type = 'button' }: BtnProps) {
   return (
-    <Box component="button" type={type} onClick={onClick} disabled={disabled} sx={{ ...btnBase, fontSize: 14, bgcolor: T.off, color: '#fff', '&:hover': { opacity: 0.9 }, '&:disabled': { bgcolor: '#373F4E', color: '#667085', cursor: 'default' } }}>
+    <Box
+      component="button"
+      type={type}
+      onClick={onClick}
+      disabled={disabled}
+      sx={{
+        ...btnBase,
+        fontSize: 14,
+        bgcolor: T.off,
+        color: '#fff',
+        '&:hover': { opacity: 0.9 },
+        '&:disabled': { bgcolor: '#373F4E', color: '#667085', cursor: 'default' },
+      }}
+    >
       {icon && <Iconify icon={icon} width={15} />}
       {children}
     </Box>
@@ -368,7 +574,14 @@ type FilterFieldProps = {
   accent?: string;
 };
 
-export function FilterField({ label, value, options, onChange, width = 180, accent = T.primary }: FilterFieldProps) {
+export function FilterField({
+  label,
+  value,
+  options,
+  onChange,
+  width = 180,
+  accent = T.primary,
+}: FilterFieldProps) {
   const [anchor, setAnchor] = useState<HTMLElement | null>(null);
   const open = !!anchor;
   const selected = options.find((o) => o.value === value);
@@ -396,14 +609,34 @@ export function FilterField({ label, value, options, onChange, width = 180, acce
         }}
       >
         {selected?.label ?? value}
-        <Iconify icon="eva:chevron-down-fill" width={16} sx={{ color: T.textSec, transform: open ? 'rotate(180deg)' : 'none', transition: 'transform .15s' }} />
+        <Iconify
+          icon="eva:chevron-down-fill"
+          width={16}
+          sx={{
+            color: T.textSec,
+            transform: open ? 'rotate(180deg)' : 'none',
+            transition: 'transform .15s',
+          }}
+        />
       </Box>
       <Popover
         open={open}
         anchorEl={anchor}
         onClose={() => setAnchor(null)}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-        slotProps={{ paper: { sx: { mt: 0.5, width, bgcolor: T.bgCard, border: `1px solid ${T.border}`, borderRadius: '6px', boxShadow: '0 10px 28px rgba(0,0,0,0.4)', p: 0.5 } } }}
+        slotProps={{
+          paper: {
+            sx: {
+              mt: 0.5,
+              width,
+              bgcolor: T.bgCard,
+              border: `1px solid ${T.border}`,
+              borderRadius: '6px',
+              boxShadow: '0 10px 28px rgba(0,0,0,0.4)',
+              p: 0.5,
+            },
+          },
+        }}
       >
         {options.map((o) => (
           <Box
@@ -435,10 +668,29 @@ export function FilterField({ label, value, options, onChange, width = 180, acce
 // SpecChip (tri-colour field chip)
 // ----------------------------------------------------------------------
 
-export function SpecChip({ tone, children }: { tone: 'green' | 'blue' | 'amber'; children: ReactNode }) {
+export function SpecChip({
+  tone,
+  children,
+}: {
+  tone: 'green' | 'blue' | 'amber';
+  children: ReactNode;
+}) {
   const c = SPEC_CHIP[tone];
   return (
-    <Box component="span" sx={{ display: 'inline-block', px: 1.25, py: '2px', borderRadius: '5px', fontSize: 14, fontFamily: FONT_MONO, bgcolor: c.bg, color: c.text, border: `1px solid ${c.text}40` }}>
+    <Box
+      component="span"
+      sx={{
+        display: 'inline-block',
+        px: 1.25,
+        py: '2px',
+        borderRadius: '5px',
+        fontSize: 14,
+        fontFamily: FONT_MONO,
+        bgcolor: c.bg,
+        color: c.text,
+        border: `1px solid ${c.text}40`,
+      }}
+    >
       {children}
     </Box>
   );
@@ -449,11 +701,25 @@ export function SpecChip({ tone, children }: { tone: 'green' | 'blue' | 'amber';
 // ----------------------------------------------------------------------
 
 export function Panel({ children, sx }: { children: ReactNode; sx?: object }) {
-  return <Box sx={{ border: `1px solid ${T.border}`, borderRadius: '8px', bgcolor: T.bgPanel, overflow: 'hidden', ...sx }}>{children}</Box>;
+  return (
+    <Box
+      sx={{
+        border: `1px solid ${T.border}`,
+        borderRadius: '8px',
+        bgcolor: T.bgPanel,
+        overflow: 'hidden',
+        ...sx,
+      }}
+    >
+      {children}
+    </Box>
+  );
 }
 
 export function SectionLabel({ children }: { children: ReactNode }) {
-  return <Typography sx={{ fontSize: 17, fontWeight: 500, color: T.textSec }}>{children}</Typography>;
+  return (
+    <Typography sx={{ fontSize: 17, fontWeight: 500, color: T.textSec }}>{children}</Typography>
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -521,7 +787,14 @@ type PagerProps = {
   onPerPageChange?: (n: number) => void;
 };
 
-export function Pager({ page, totalPages, perPage, perPageOptions = [10, 20, 40, 60], onPageChange, onPerPageChange }: PagerProps) {
+export function Pager({
+  page,
+  totalPages,
+  perPage,
+  perPageOptions = [10, 20, 40, 60],
+  onPageChange,
+  onPerPageChange,
+}: PagerProps) {
   const { t } = useTranslate();
   const [anchor, setAnchor] = useState<HTMLElement | null>(null);
   const canPrev = page > 1;
@@ -533,21 +806,73 @@ export function Pager({ page, totalPages, perPage, perPageOptions = [10, 20, 40,
   for (let i = start; i <= Math.min(totalPages, start + 4); i += 1) pages.push(i);
 
   return (
-    <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ bgcolor: T.bgCard, border: `1px solid ${T.border}`, borderRadius: '8px', p: '8px 14px' }}>
+    <Stack
+      direction="row"
+      alignItems="center"
+      justifyContent="space-between"
+      sx={{
+        bgcolor: T.bgCard,
+        border: `1px solid ${T.border}`,
+        borderRadius: '8px',
+        p: '8px 14px',
+      }}
+    >
       <Stack direction="row" alignItems="center" spacing={1}>
         <Typography sx={{ fontSize: 14, color: T.textSec }}>{t('table.rows_per_page')}:</Typography>
         {onPerPageChange && (
           <>
             <Box
               onClick={(e) => setAnchor(e.currentTarget)}
-              sx={{ height: 30, px: 1, display: 'flex', alignItems: 'center', gap: 0.5, bgcolor: T.bgPanel, border: `1px solid ${T.border}`, borderRadius: '5px', fontSize: 14, color: T.textPrim, cursor: 'pointer' }}
+              sx={{
+                height: 30,
+                px: 1,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.5,
+                bgcolor: T.bgPanel,
+                border: `1px solid ${T.border}`,
+                borderRadius: '5px',
+                fontSize: 14,
+                color: T.textPrim,
+                cursor: 'pointer',
+              }}
             >
               {perPage}
               <Iconify icon="eva:chevron-down-fill" width={14} sx={{ color: T.textSec }} />
             </Box>
-            <Popover open={!!anchor} anchorEl={anchor} onClose={() => setAnchor(null)} slotProps={{ paper: { sx: { mt: 0.5, bgcolor: T.bgCard, border: `1px solid ${T.border}`, borderRadius: '6px', p: 0.5 } } }}>
+            <Popover
+              open={!!anchor}
+              anchorEl={anchor}
+              onClose={() => setAnchor(null)}
+              slotProps={{
+                paper: {
+                  sx: {
+                    mt: 0.5,
+                    bgcolor: T.bgCard,
+                    border: `1px solid ${T.border}`,
+                    borderRadius: '6px',
+                    p: 0.5,
+                  },
+                },
+              }}
+            >
               {perPageOptions.map((n) => (
-                <Box key={n} onClick={() => { onPerPageChange(n); setAnchor(null); }} sx={{ px: 1.5, py: 0.75, borderRadius: '4px', fontSize: 14, color: n === perPage ? T.primary : T.textPrim, cursor: 'pointer', '&:hover': { bgcolor: T.bgHover } }}>
+                <Box
+                  key={n}
+                  onClick={() => {
+                    onPerPageChange(n);
+                    setAnchor(null);
+                  }}
+                  sx={{
+                    px: 1.5,
+                    py: 0.75,
+                    borderRadius: '4px',
+                    fontSize: 14,
+                    color: n === perPage ? T.primary : T.textPrim,
+                    cursor: 'pointer',
+                    '&:hover': { bgcolor: T.bgHover },
+                  }}
+                >
                   {n}
                 </Box>
               ))}
@@ -557,8 +882,16 @@ export function Pager({ page, totalPages, perPage, perPageOptions = [10, 20, 40,
       </Stack>
 
       <Stack direction="row" alignItems="center" spacing={0.5}>
-        <PagerArrow icon="eva:arrowhead-left-fill" disabled={!canPrev} onClick={() => onPageChange(1)} />
-        <PagerArrow icon="eva:arrow-ios-back-fill" disabled={!canPrev} onClick={() => onPageChange(page - 1)} />
+        <PagerArrow
+          icon="eva:arrowhead-left-fill"
+          disabled={!canPrev}
+          onClick={() => onPageChange(1)}
+        />
+        <PagerArrow
+          icon="eva:arrow-ios-back-fill"
+          disabled={!canPrev}
+          onClick={() => onPageChange(page - 1)}
+        />
         {pages.map((p) => (
           <Box
             key={p}
@@ -580,14 +913,30 @@ export function Pager({ page, totalPages, perPage, perPageOptions = [10, 20, 40,
             {p}
           </Box>
         ))}
-        <PagerArrow icon="eva:arrow-ios-forward-fill" disabled={!canNext} onClick={() => onPageChange(page + 1)} />
-        <PagerArrow icon="eva:arrowhead-right-fill" disabled={!canNext} onClick={() => onPageChange(totalPages)} />
+        <PagerArrow
+          icon="eva:arrow-ios-forward-fill"
+          disabled={!canNext}
+          onClick={() => onPageChange(page + 1)}
+        />
+        <PagerArrow
+          icon="eva:arrowhead-right-fill"
+          disabled={!canNext}
+          onClick={() => onPageChange(totalPages)}
+        />
       </Stack>
     </Stack>
   );
 }
 
-function PagerArrow({ icon, disabled, onClick }: { icon: string; disabled: boolean; onClick: () => void }) {
+function PagerArrow({
+  icon,
+  disabled,
+  onClick,
+}: {
+  icon: string;
+  disabled: boolean;
+  onClick: () => void;
+}) {
   return (
     <Box
       component="button"

--- a/src/components/viewport-zoom/index.tsx
+++ b/src/components/viewport-zoom/index.tsx
@@ -1,27 +1,48 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useState, useEffect } from 'react';
 
 // ----------------------------------------------------------------------
 // Replicates k-control-fe-ui's viewport scaler: the design is fixed to a
 // 1536×864 desktop baseline, so we zoom the root proportionally to fit smaller
-// viewports (never upscaling, floor 0.7). This makes the whole app render at
-// the reference's density/scale identically across screen sizes.
+// viewports (never upscaling, floor 0.7). The zoom is continuous across ALL
+// widths — including below the sidebar breakpoint — so shrinking the window
+// scales the whole app smoothly instead of snapping back to 1:1 at 1200px.
 // ----------------------------------------------------------------------
 
 const BASE_W = 1536;
 const BASE_H = 864;
 const MIN = 0.7;
 
-// The root `zoom` factor currently applied to <html>. 1 on the reference-sized
-// (or larger) desktop, down to MIN on smaller viewports. Exported so components
-// that are incompatible with an ancestor CSS `zoom` (e.g. React Flow, which
-// ignores it when measuring handles/edges) can read and counteract it.
+// Viewport width (px) at/above which the sidebar uses its full desktop layout;
+// below it, the sidebar swaps to the compact 140px rail. This only drives the
+// sidebar swap — the root zoom keeps scaling continuously on both sides.
+export const DESKTOP_MIN_WIDTH = 1200;
+
+// The root `zoom` factor applied to <html> — scaled to the reference baseline
+// (down to MIN), continuous across all widths. Exported so components
+// incompatible with an ancestor CSS `zoom` (e.g. React Flow, which ignores it
+// when measuring handles/edges) can read and counteract it.
 export function getViewportScale() {
   if (typeof window === 'undefined') return 1;
   const w = window.innerWidth;
   const h = window.innerHeight;
   return Math.min(1, Math.max(MIN, Math.min(w / BASE_W, h / BASE_H)));
+}
+
+// True while the viewport is at/above the sidebar breakpoint. Drives the
+// desktop⇄compact sidebar swap. Uses window.innerWidth (unaffected by the root
+// CSS `zoom`) rather than a media query, so it agrees exactly with the
+// DESKTOP_MIN_WIDTH boundary.
+export function useIsDesktopViewport() {
+  const [isDesktop, setIsDesktop] = useState(true);
+  useEffect(() => {
+    const update = () => setIsDesktop(window.innerWidth >= DESKTOP_MIN_WIDTH);
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, []);
+  return isDesktop;
 }
 
 export function ViewportZoom() {

--- a/src/components/viewport-zoom/index.tsx
+++ b/src/components/viewport-zoom/index.tsx
@@ -5,14 +5,14 @@ import { useState, useEffect } from 'react';
 // ----------------------------------------------------------------------
 // Replicates k-control-fe-ui's viewport scaler: the design is fixed to a
 // 1536×864 desktop baseline, so we zoom the root proportionally to fit smaller
-// viewports (never upscaling, floor 0.7). The zoom is continuous across ALL
+// viewports (never upscaling, floor 0.8). The zoom is continuous across ALL
 // widths — including below the sidebar breakpoint — so shrinking the window
 // scales the whole app smoothly instead of snapping back to 1:1 at 1200px.
 // ----------------------------------------------------------------------
 
 const BASE_W = 1536;
 const BASE_H = 864;
-const MIN = 0.7;
+const MIN = 0.8;
 
 // Viewport width (px) at/above which the sidebar uses its full desktop layout;
 // below it, the sidebar swaps to the compact 140px rail. This only drives the

--- a/src/components/viewport-zoom/index.tsx
+++ b/src/components/viewport-zoom/index.tsx
@@ -13,14 +13,22 @@ const BASE_W = 1536;
 const BASE_H = 864;
 const MIN = 0.7;
 
+// The root `zoom` factor currently applied to <html>. 1 on the reference-sized
+// (or larger) desktop, down to MIN on smaller viewports. Exported so components
+// that are incompatible with an ancestor CSS `zoom` (e.g. React Flow, which
+// ignores it when measuring handles/edges) can read and counteract it.
+export function getViewportScale() {
+  if (typeof window === 'undefined') return 1;
+  const w = window.innerWidth;
+  const h = window.innerHeight;
+  return Math.min(1, Math.max(MIN, Math.min(w / BASE_W, h / BASE_H)));
+}
+
 export function ViewportZoom() {
   useEffect(() => {
     const apply = () => {
-      const w = window.innerWidth;
-      const h = window.innerHeight;
-      const scale = Math.min(1, Math.max(MIN, Math.min(w / BASE_W, h / BASE_H)));
       // `zoom` (not transform) so fixed/sticky positioning still works.
-      (document.documentElement.style as any).zoom = String(scale);
+      (document.documentElement.style as any).zoom = String(getViewportScale());
     };
     apply();
     window.addEventListener('resize', apply);

--- a/src/global.css
+++ b/src/global.css
@@ -107,30 +107,44 @@ input[type='number']::-webkit-inner-spin-button {
 
 /** **************************************
 * Scrollbar: Dark Theme
+* Invisible at rest, revealed on hover of the scrollable area (both axes).
+* The gutter is still reserved so content doesn't shift when the thumb fades in.
 *************************************** */
 
 /* Chrome, Edge, Safari */
 ::-webkit-scrollbar {
-  width: 4px;
-  height: 4px;
+  width: 8px;
+  height: 8px;
 }
 
 ::-webkit-scrollbar-track {
   background: transparent;
 }
 
+/* Thumb transparent at rest → fades in when its scroll area (or anything
+   inside it) is hovered, and darkens when the thumb itself is hovered. */
 ::-webkit-scrollbar-thumb {
-  background-color: #33343f;
-  border-radius: 2px;
+  background-color: transparent;
+  border-radius: 4px;
+  transition: background-color 0.2s ease;
 }
 
-::-webkit-scrollbar-thumb:hover {
+:hover::-webkit-scrollbar-thumb {
+  background-color: #33343f;
+}
+
+::-webkit-scrollbar-thumb:hover,
+:hover::-webkit-scrollbar-thumb:hover {
   background-color: #4e576a;
 }
 
-/* Firefox */
+/* Firefox — thin track kept, colours transparent until the area is hovered. */
 * {
   scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+}
+
+*:hover {
   scrollbar-color: #33343f transparent;
 }
 

--- a/src/layouts/dashboard/nav-vertical-v5.tsx
+++ b/src/layouts/dashboard/nav-vertical-v5.tsx
@@ -23,6 +23,7 @@ import { useAuditLogList, useGetChannelList } from 'src/actions/nodes';
 import { useGetProcesses, useGetMemoryMetrics } from 'src/actions/dashboard';
 
 import { KIcon } from 'src/components/k-icons';
+import { useIsDesktopViewport } from 'src/components/viewport-zoom';
 
 import { useAuthContext } from 'src/auth/hooks';
 import { signOut } from 'src/auth/context/jwt/action';
@@ -38,6 +39,12 @@ export function NavVerticalV5({ nodes }: NavVerticalV5Props) {
   const pathname = usePathname();
   const router = useRouter();
   const { user, checkUserSession } = useAuthContext();
+
+  // Below the desktop breakpoint (1200px) the sidebar switches to the compact
+  // 140px rail (per Figma): a node stepper instead of the combo, single-column
+  // stat tiles, and a narrower shell. Everything else is shared.
+  const isDesktop = useIsDesktopViewport();
+  const compact = !isDesktop;
 
   const nodeIds = useMemo(() => nodes.map((n) => n.id), [nodes]);
 
@@ -113,7 +120,10 @@ export function NavVerticalV5({ nodes }: NavVerticalV5Props) {
     { label: t('tab_option.spec_list'), path: paths.dashboard.nodes.specList(activeNode) },
     { label: t('tab_option.identify_list'), path: paths.dashboard.nodes.identifyList(activeNode) },
     { label: t('tab_option.function_list'), path: paths.dashboard.nodes.functionList(activeNode) },
-    { label: t('tab_option.daily_report_list'), path: paths.dashboard.nodes.dailyReportList(activeNode) },
+    {
+      label: t('tab_option.daily_report_list'),
+      path: paths.dashboard.nodes.dailyReportList(activeNode),
+    },
     { label: t('tab_option.alerts_list'), path: paths.dashboard.nodes.alertsList(activeNode) },
   ];
 
@@ -125,7 +135,7 @@ export function NavVerticalV5({ nodes }: NavVerticalV5Props) {
         flexShrink: 0,
         display: 'flex',
         flexDirection: 'column',
-        width: '268px',
+        width: compact ? '140px' : '268px',
         bgcolor: T.bgPanel,
         borderRight: `1px solid ${T.border}`,
         overflow: 'hidden',
@@ -148,25 +158,67 @@ export function NavVerticalV5({ nodes }: NavVerticalV5Props) {
           alt="PMR"
           sx={{ height: 24, width: 'auto', display: 'block' }}
         />
-        <Box sx={{ width: 24, height: 24, display: 'flex', alignItems: 'center', justifyContent: 'center', color: T.textDim, cursor: 'pointer' }}>
-          <KIcon name="scrap" size={18} />
-        </Box>
+        {!compact && (
+          <Box
+            sx={{
+              width: 24,
+              height: 24,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: T.textDim,
+              cursor: 'pointer',
+            }}
+          >
+            <KIcon name="scrap" size={18} />
+          </Box>
+        )}
       </Box>
 
       {/* Nav list */}
-      <Box className="no-scrollbar" sx={{ flex: 1, p: 1.25, display: 'flex', flexDirection: 'column', gap: 0.5, overflowY: 'auto' }}>
-        <NavRow label={t('side_bar.dashboard')} icon="home" active={dashActive} onClick={() => router.push(paths.dashboard.root)} />
+      <Box
+        className="no-scrollbar"
+        sx={{
+          flex: 1,
+          p: 1.25,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 0.5,
+          overflowY: 'auto',
+        }}
+      >
+        <NavRow
+          label={t('side_bar.dashboard')}
+          icon="home"
+          active={dashActive}
+          onClick={() => router.push(paths.dashboard.root)}
+        />
 
-        <NavRow label={t('side_bar.nodes')} icon="certified" expandable open={nodeOpen} onClick={() => setNodeOpen((v) => !v)} />
+        <NavRow
+          label={t('side_bar.nodes')}
+          icon="certified"
+          expandable
+          open={nodeOpen}
+          onClick={() => setNodeOpen((v) => !v)}
+        />
 
         {nodeOpen && (
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, mt: 0.25 }}>
-            <NodeCombo
-              nodes={nodes}
-              activeNode={activeNode}
-              online={nodeOnline}
-              onSelect={switchNode}
-            />
+            {compact ? (
+              <NodeStepper
+                nodes={nodes}
+                activeNode={activeNode}
+                online={nodeOnline}
+                onSelect={switchNode}
+              />
+            ) : (
+              <NodeCombo
+                nodes={nodes}
+                activeNode={activeNode}
+                online={nodeOnline}
+                onSelect={switchNode}
+              />
+            )}
 
             {activeNode && (
               <NodeTiles
@@ -174,6 +226,7 @@ export function NavVerticalV5({ nodes }: NavVerticalV5Props) {
                 nodeOnline={nodeOnline}
                 isActive={isActive}
                 onNavigate={(p) => router.push(p)}
+                columns={compact ? 1 : 2}
                 t={t}
               />
             )}
@@ -182,7 +235,13 @@ export function NavVerticalV5({ nodes }: NavVerticalV5Props) {
               <Box>
                 <GroupHeader label={t('group.settings_list')} />
                 {listMenu.map((item) => (
-                  <NavRow key={item.path} label={item.label} indent={2} active={isActive(item.path)} onClick={() => router.push(item.path)} />
+                  <NavRow
+                    key={item.path}
+                    label={item.label}
+                    indent={2}
+                    active={isActive(item.path)}
+                    onClick={() => router.push(item.path)}
+                  />
                 ))}
               </Box>
             )}
@@ -191,26 +250,92 @@ export function NavVerticalV5({ nodes }: NavVerticalV5Props) {
       </Box>
 
       {/* Bottom block */}
-      <Box sx={{ borderTop: `1px solid ${T.border}`, p: 1, display: 'flex', flexDirection: 'column', gap: 0.25 }}>
+      <Box
+        sx={{
+          borderTop: `1px solid ${T.border}`,
+          p: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 0.25,
+        }}
+      >
         <Box
           onClick={() => router.push('/dashboard/settings')}
-          sx={{ display: 'flex', alignItems: 'center', gap: 1.375, px: 1.5, py: 1.125, borderRadius: 1, color: T.textSec, fontSize: 15, cursor: 'pointer', '&:hover': { bgcolor: T.bgHover, color: T.textPrim } }}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1.375,
+            px: 1.5,
+            py: 1.125,
+            borderRadius: 1,
+            color: T.textSec,
+            fontSize: 15,
+            cursor: 'pointer',
+            '&:hover': { bgcolor: T.bgHover, color: T.textPrim },
+          }}
         >
           <KIcon name="settings" size={16} />
           {t('side_bar.settings')}
         </Box>
 
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.125, px: 1.25, py: 1, borderRadius: 1 }}>
-          <Box sx={{ width: 28, height: 28, borderRadius: '50%', background: `linear-gradient(135deg, ${T.primary}, ${T.primary})`, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 13, fontWeight: 500, color: T.onFill, flexShrink: 0 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1.125,
+            px: 1.25,
+            py: 1,
+            borderRadius: 1,
+          }}
+        >
+          <Box
+            sx={{
+              width: 28,
+              height: 28,
+              borderRadius: '50%',
+              background: `linear-gradient(135deg, ${T.primary}, ${T.primary})`,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: 13,
+              fontWeight: 500,
+              color: T.onFill,
+              flexShrink: 0,
+            }}
+          >
             {initials}
           </Box>
           <Box sx={{ flex: 1, minWidth: 0 }}>
-            <Typography sx={{ fontSize: 14, fontWeight: 500, color: T.textPrim, lineHeight: 1.3, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{displayName}</Typography>
-            <Typography sx={{ fontSize: 12, color: T.textSec, lineHeight: 1.3 }}>{teamName}</Typography>
+            <Typography
+              sx={{
+                fontSize: 14,
+                fontWeight: 500,
+                color: T.textPrim,
+                lineHeight: 1.3,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {displayName}
+            </Typography>
+            <Typography sx={{ fontSize: 12, color: T.textSec, lineHeight: 1.3 }}>
+              {teamName}
+            </Typography>
           </Box>
           <Box
             onClick={handleLogout}
-            sx={{ width: 30, height: 30, display: 'flex', alignItems: 'center', justifyContent: 'center', borderRadius: 1, color: T.textDim, cursor: 'pointer', '&:hover': { bgcolor: T.offBg, color: T.off } }}
+            sx={{
+              width: 30,
+              height: 30,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              borderRadius: 1,
+              color: T.textDim,
+              cursor: 'pointer',
+              '&:hover': { bgcolor: T.offBg, color: T.off },
+            }}
           >
             <KIcon name="logout" size={17} />
           </Box>
@@ -229,10 +354,11 @@ type NodeTilesProps = {
   nodeOnline: boolean;
   isActive: (path: string) => boolean;
   onNavigate: (path: string) => void;
+  columns?: 1 | 2;
   t: (key: string) => string;
 };
 
-function NodeTiles({ node, nodeOnline, isActive, onNavigate, t }: NodeTilesProps) {
+function NodeTiles({ node, nodeOnline, isActive, onNavigate, columns = 2, t }: NodeTilesProps) {
   const { processes } = useGetProcesses(node) as { processes: any[] };
   const { channels: inChannels } = useGetChannelList(node, 'inbound') as { channels: any[] };
   const { channels: outChannels } = useGetChannelList(node, 'outbound') as { channels: any[] };
@@ -240,7 +366,9 @@ function NodeTiles({ node, nodeOnline, isActive, onNavigate, t }: NodeTilesProps
   const { auditLogs } = useAuditLogList(node, 'all', 1, 1000);
   const { data: layoutData } = useSWR(node ? endpoints.layouts.list(node) : null, fetcher);
 
-  const layoutCount = (layoutData?.data?.list?.length ?? layoutData?.data?.layoutList?.length) as number | undefined;
+  const layoutCount = (layoutData?.data?.list?.length ?? layoutData?.data?.layoutList?.length) as
+    | number
+    | undefined;
   const memUsage = memoryMetricsData?.mem_usage;
 
   // Total audit-log disk usage = sum of every audit-log file's size (bytes).
@@ -257,24 +385,53 @@ function NodeTiles({ node, nodeOnline, isActive, onNavigate, t }: NodeTilesProps
           tone: nodeOnline ? 'on' : 'dim',
           path: paths.dashboard.nodes.dashboard(node),
         },
-        { label: t('tab_option.process'), value: processes?.length != null ? String(processes.length) : '', path: paths.dashboard.nodes.process(node) },
-        { label: t('tab_option.memory'), value: memUsage != null ? `${memUsage}%` : '', path: paths.dashboard.nodes.memory(node) },
+        {
+          label: t('tab_option.process'),
+          value: processes?.length != null ? String(processes.length) : '',
+          path: paths.dashboard.nodes.process(node),
+        },
+        {
+          label: t('tab_option.memory'),
+          value: memUsage != null ? `${memUsage}%` : '',
+          path: paths.dashboard.nodes.memory(node),
+        },
         {
           label: t('tab_option.status'),
           value: nodeOnline ? t('tile.normal') : t('tile.abnormal'),
           tone: nodeOnline ? 'default' : 'off',
           path: paths.dashboard.nodes.status(node),
         },
-        { label: t('tab_option.replay'), value: '', tone: 'dim', path: paths.dashboard.nodes.replay(node) },
+        {
+          label: t('tab_option.replay'),
+          value: '',
+          tone: 'dim',
+          path: paths.dashboard.nodes.replay(node),
+        },
       ],
     },
     {
       label: t('group.data'),
       tiles: [
-        { label: t('tab_option.audit_log'), value: auditTotal, path: paths.dashboard.nodes.auditLog(node) },
-        { label: t('tab_option.layout_list'), value: layoutCount != null ? String(layoutCount) : '', path: paths.dashboard.nodes.layoutList(node) },
-        { label: t('tab_option.channels_inbound'), value: inChannels?.length != null ? String(inChannels.length) : '', path: paths.dashboard.nodes.channelsInbound(node) },
-        { label: t('tab_option.channels_outbound'), value: outChannels?.length != null ? String(outChannels.length) : '', path: paths.dashboard.nodes.channelsOutbound(node) },
+        {
+          label: t('tab_option.audit_log'),
+          value: auditTotal,
+          path: paths.dashboard.nodes.auditLog(node),
+        },
+        {
+          label: t('tab_option.layout_list'),
+          value: layoutCount != null ? String(layoutCount) : '',
+          path: paths.dashboard.nodes.layoutList(node),
+        },
+        {
+          label: t('tab_option.channels_inbound'),
+          value: inChannels?.length != null ? String(inChannels.length) : '',
+          path: paths.dashboard.nodes.channelsInbound(node),
+        },
+        {
+          label: t('tab_option.channels_outbound'),
+          value: outChannels?.length != null ? String(outChannels.length) : '',
+          path: paths.dashboard.nodes.channelsOutbound(node),
+        },
       ],
     },
   ];
@@ -292,6 +449,7 @@ function NodeTiles({ node, nodeOnline, isActive, onNavigate, t }: NodeTilesProps
                 value={tile.value}
                 tone={(tile as any).tone || 'default'}
                 active={isActive(tile.path)}
+                columns={columns}
                 onClick={() => onNavigate(tile.path)}
               />
             ))}
@@ -341,13 +499,33 @@ function NavRow({ label, icon, indent = 0, active, expandable, open, onClick }: 
       }}
     >
       {icon && (
-        <Box sx={{ width: 16, height: 16, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+        <Box
+          sx={{
+            width: 16,
+            height: 16,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexShrink: 0,
+          }}
+        >
           <KIcon name={icon} size={15} />
         </Box>
       )}
-      <Box sx={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{label}</Box>
+      <Box sx={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {label}
+      </Box>
       {expandable && (
-        <Box component="span" sx={{ fontSize: 17, opacity: 0.5, flexShrink: 0, transform: open ? 'rotate(90deg)' : 'none', transition: 'transform .15s' }}>
+        <Box
+          component="span"
+          sx={{
+            fontSize: 17,
+            opacity: 0.5,
+            flexShrink: 0,
+            transform: open ? 'rotate(90deg)' : 'none',
+            transition: 'transform .15s',
+          }}
+        >
           ›
         </Box>
       )}
@@ -357,7 +535,17 @@ function NavRow({ label, icon, indent = 0, active, expandable, open, onClick }: 
 
 function GroupHeader({ label }: { label: string }) {
   return (
-    <Typography sx={{ fontSize: 12, fontWeight: 500, color: T.textDim, letterSpacing: '0.04em', px: 0.5, pt: 1.25, pb: 0.5 }}>
+    <Typography
+      sx={{
+        fontSize: 12,
+        fontWeight: 500,
+        color: T.textDim,
+        letterSpacing: '0.04em',
+        px: 0.5,
+        pt: 1.25,
+        pb: 0.5,
+      }}
+    >
       {label}
     </Typography>
   );
@@ -368,10 +556,11 @@ type MenuTileProps = {
   value?: string;
   tone?: string;
   active?: boolean;
+  columns?: 1 | 2;
   onClick?: () => void;
 };
 
-function MenuTile({ label, value, tone = 'default', active, onClick }: MenuTileProps) {
+function MenuTile({ label, value, tone = 'default', active, columns = 2, onClick }: MenuTileProps) {
   const valueColor = active
     ? '#FFFFFF'
     : tone === 'on'
@@ -382,14 +571,18 @@ function MenuTile({ label, value, tone = 'default', active, onClick }: MenuTileP
           ? T.textDim
           : T.textPrim;
 
+  // Single-column (compact rail) tiles span the full width; the default 2-up
+  // grid keeps each tile at half width minus the row gap.
+  const basis = columns === 1 ? '100%' : 'calc(50% - 4px)';
+
   return (
     <Box
       component="button"
       onClick={onClick}
       sx={{
-        flex: '1 1 calc(50% - 4px)',
-        minWidth: 'calc(50% - 4px)',
-        maxWidth: 'calc(50% - 4px)',
+        flex: `1 1 ${basis}`,
+        minWidth: basis,
+        maxWidth: basis,
         textAlign: 'left',
         border: 'none',
         p: '10px 11px',
@@ -400,8 +593,16 @@ function MenuTile({ label, value, tone = 'default', active, onClick }: MenuTileP
         '&:hover': active ? undefined : { bgcolor: T.bgHover },
       }}
     >
-      <Typography sx={{ fontSize: 13, color: active ? 'rgba(255,255,255,0.8)' : T.textSec, lineHeight: 1.4 }}>{label}</Typography>
-      <Typography sx={{ fontSize: 16, fontWeight: 400, color: valueColor, lineHeight: 1.3, minHeight: 21 }}>{value ?? ''}</Typography>
+      <Typography
+        sx={{ fontSize: 13, color: active ? 'rgba(255,255,255,0.8)' : T.textSec, lineHeight: 1.4 }}
+      >
+        {label}
+      </Typography>
+      <Typography
+        sx={{ fontSize: 16, fontWeight: 400, color: valueColor, lineHeight: 1.3, minHeight: 21 }}
+      >
+        {value ?? ''}
+      </Typography>
     </Box>
   );
 }
@@ -470,7 +671,9 @@ function NodeCombo({ nodes, activeNode, online, onSelect }: NodeComboProps) {
             }}
           >
             <StatusDot online={nOnline} />
-            <Box sx={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            <Box
+              sx={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+            >
               {option.id}
             </Box>
           </Box>
@@ -528,5 +731,94 @@ function NodeCombo({ nodes, activeNode, online, onSelect }: NodeComboProps) {
         },
       }}
     />
+  );
+}
+
+// ----------------------------------------------------------------------
+// NodeStepper — compact-rail node switcher: status dot + node id + up/down
+// steppers that cycle through the node list (the combo is too wide at 140px).
+// ----------------------------------------------------------------------
+
+function NodeStepper({ nodes, activeNode, online, onSelect }: NodeComboProps) {
+  const idx = nodes.findIndex((n) => n.id === activeNode);
+
+  const step = useCallback(
+    (dir: 1 | -1) => {
+      if (!nodes.length) return;
+      const base = idx < 0 ? 0 : idx;
+      const next = (base + dir + nodes.length) % nodes.length;
+      onSelect(nodes[next].id);
+    },
+    [nodes, idx, onSelect]
+  );
+
+  const disabled = nodes.length <= 1;
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '7px',
+        bgcolor: T.bgCard,
+        border: `1px solid ${T.border}`,
+        borderRadius: '5px',
+        pl: '13px',
+        pr: '7px',
+        py: '6px',
+      }}
+    >
+      <StatusDot online={online} glow />
+      <Box
+        sx={{
+          flex: 1,
+          minWidth: 0,
+          fontSize: 14,
+          fontWeight: 500,
+          color: T.textPrim,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {activeNode || '—'}
+      </Box>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1px', flexShrink: 0 }}>
+        <StepBtn up disabled={disabled} onClick={() => step(-1)} />
+        <StepBtn disabled={disabled} onClick={() => step(1)} />
+      </Box>
+    </Box>
+  );
+}
+
+function StepBtn({
+  up,
+  disabled,
+  onClick,
+}: {
+  up?: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <Box
+      onClick={disabled ? undefined : onClick}
+      sx={{
+        width: 22,
+        height: 16,
+        borderRadius: '3px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: T.textSec,
+        opacity: disabled ? 0.25 : 1,
+        cursor: disabled ? 'default' : 'pointer',
+        '&:hover': disabled ? undefined : { bgcolor: T.bgHover, color: T.textPrim },
+      }}
+    >
+      <Box sx={{ display: 'flex', transform: up ? 'rotate(180deg)' : 'none' }}>
+        <KIcon name="chevronDown" size={13} />
+      </Box>
+    </Box>
   );
 }

--- a/src/theme/core/components/mui-x-data-grid.tsx
+++ b/src/theme/core/components/mui-x-data-grid.tsx
@@ -105,8 +105,9 @@ const MuiDataGrid: Components<Theme>['MuiDataGrid'] = {
         '--DataGrid-containerBackground': theme.vars.palette.background.neutral,
         '--unstable_DataGrid-headWeight': theme.typography.fontWeightSemiBold,
         borderWidth: 0,
+        // Scrollbar colour deferred to the global hover-reveal rule (invisible
+        // at rest, shown on hover); keep the thin width.
         scrollbarWidth: 'thin',
-        scrollbarColor: `${varAlpha(theme.vars.palette.text.disabledChannel, 0.4)} ${varAlpha(theme.vars.palette.text.disabledChannel, 0.08)}`,
         '& .MuiDataGrid-filler > div': { borderTopStyle: 'dashed' },
         '& .MuiDataGrid-topContainer::after': { height: 0 },
         '& .MuiDataGrid-virtualScrollerContent': {


### PR DESCRIPTION
## 개요
반응형 레이아웃 작업 + Data Flow 캔버스 개선 모음입니다. 1200px 이하에서 앱이 자연스럽게 축소되고, 사이드바·테이블·스크롤바·Data Flow가 화면 크기에 맞춰 동작합니다.

## 주요 변경

### 반응형 레이아웃
- **연속 루트 줌**: 창 크기에 따라 앱 전체를 매끄럽게 축소(하한 0.8). 1200px 경계에서 튀지 않고 이어짐
- **compact 사이드바**: 1200px 이하에서 268px → **140px 레일**로 전환 (Figma 디자인 반영). 노드 스테퍼(▲▼), 단일 컬럼 타일. 기존 데이터 배선 재사용
- **테이블**: 좁은 화면에서 설명(grow) 컬럼만 붕괴하던 문제 수정 → `min-width: max-content`로 컬럼 폭 유지하고 가로 스크롤

### 스크롤바
- **hover-reveal**: 평소 투명 → 스크롤 영역 호버 시에만 나타남 (가로·세로, Chrome/Firefox). 모달·DataGrid의 개별 override 제거해 전역 통일

### Data Flow 캔버스
- **엣지 정렬 수정**: React Flow가 조상 CSS `zoom`을 인식 못 해 엣지가 연결점에서 분리되던 문제 → counter-zoom으로 해결 (헤드리스 실측: 38px → 1.1px)
- **반응형 축소**: 그래프가 루트 줌과 같은 비율로 축소되게 함 + 안내 문구 폰트 크기도 반응형
- **그리드/줌버튼 위치**: counter-zoom 레이어가 폭의 80%만 채워 그리드가 오른쪽에서 잘리고 줌버튼이 중간에 있던 문제 수정
- **테스트 환경 모달**: 반투명 백드롭 → 불투명으로 변경해 뒤 화면 완전 차단

## 검증
Chrome 헤드리스(puppeteer)로 여러 뷰포트에서 실측·스크린샷 검증 (엣지 정렬, 사이드바 스왑, 그래프 비율, 테이블 스크롤, 그리드/패널 위치). 타입체크·eslint·prettier 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
